### PR TITLE
Fix market data timeframes

### DIFF
--- a/backtesting.py
+++ b/backtesting.py
@@ -78,7 +78,7 @@ def simulate_day(pair: Pair, date: pd.Timestamp, backtesting: pd.DataFrame, unin
 def perform_backtest(pairs: list[Pair]) -> pd.DataFrame:
     if not all(pair.data['Signal'].index.equals(pairs[0].data['Signal'].index) for pair in pairs[1:]): #this should never happen
         sys.exit('All spreads must have the same index for backtesting.')
-
+    
     backtesting = pd.DataFrame(index=pairs[0].data['Signal'].dropna().index)
     backtesting['Capital'] = pd.Series(index=backtesting.index, dtype=float)
     backtesting['Entries'] = 0

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -28,7 +28,7 @@ def get_historic_data() -> pd.DataFrame:
 
     return historic_data
 
-def get_backtesting_data(dependent_stock: str, independent_stock: str) -> pd.Series:
+def get_backtesting_data(dependent_stock: str, independent_stock: str) -> pd.DataFrame:
     current_date = datetime.now()
     backtesting_data = get_market_data([dependent_stock, independent_stock], current_date)
     
@@ -44,8 +44,9 @@ def get_returns(adjusted_data: pd.DataFrame) -> pd.DataFrame:
 
     return filtered_returns
 
-def get_backtesting_spread(pair: Pair) -> pd.Series:
-    backtesting_data = get_backtesting_data(pair.independent_stock, pair.dependent_stock)
-    backtesting_spread = backtesting_data[pair.dependent_stock] - pair.hedge_ratio * backtesting_data[pair.independent_stock]
-
-    return backtesting_spread.replace([np.inf, -np.inf], np.nan).dropna()
+def update_for_backtesting(pair: Pair) -> None:
+    backtesting_prices = get_backtesting_data(pair.dependent_stock, pair.independent_stock)
+    pair.data = pair.data.reindex(backtesting_prices.index)
+    pair.data[pair.dependent_stock] = backtesting_prices[pair.dependent_stock]
+    pair.data[pair.independent_stock] = backtesting_prices[pair.independent_stock]
+    pair.data['Spread'] = pair.data[pair.dependent_stock] - pair.hedge_ratio * pair.data[pair.independent_stock]

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -5,24 +5,34 @@ import yfinance as yf
 
 from datetime import datetime, timedelta
 
+from pair import Pair
 from tickers import TICKERS
 
-def get_market_data() -> pd.DataFrame:
-    start_date = datetime.now() - timedelta(days=6*365)
-
-    historic_data = yf.download(tickers=TICKERS, start=start_date, period='3y', auto_adjust=False, progress=False)
+def get_market_data(tickers: list[str], end_date: datetime) -> pd.DataFrame:
+    market_data = yf.download(tickers=tickers, end=end_date, period='3y', auto_adjust=False, progress=False)
 
     failed_tickers = list(yf.shared._ERRORS.keys())
     if failed_tickers:
         sys.exit('Failed to download market data for: ' + str(failed_tickers))
-
-    # for this to work with a vpn, i need to switch country every time it runs?
-    if 'Adj Close' in historic_data.columns:
-        adjusted_data = historic_data['Adj Close']
+    
+    if 'Adj Close' in market_data.columns:
+        adjusted_data = market_data['Adj Close']
     else:
-        adjusted_data = historic_data['Close']
+        adjusted_data = market_data['Close']
 
     return adjusted_data
+
+def get_historic_data() -> pd.DataFrame:
+    end_date = datetime.now() - timedelta(days=3*365)
+    historic_data = get_market_data(TICKERS, end_date)
+
+    return historic_data
+
+def get_backtesting_data(dependent_stock: str, independent_stock: str) -> pd.Series:
+    current_date = datetime.now()
+    backtesting_data = get_market_data([dependent_stock, independent_stock], current_date)
+    
+    return backtesting_data
 
 def get_returns(adjusted_data: pd.DataFrame) -> pd.DataFrame:
     enough_trading_days = adjusted_data.notna().sum() > 700
@@ -33,3 +43,9 @@ def get_returns(adjusted_data: pd.DataFrame) -> pd.DataFrame:
     filtered_returns = returns.loc[:, enough_moving_days]
 
     return filtered_returns
+
+def get_backtesting_spread(pair: Pair) -> pd.Series:
+    backtesting_data = get_backtesting_data(pair.independent_stock, pair.dependent_stock)
+    backtesting_spread = backtesting_data[pair.dependent_stock] - pair.hedge_ratio * backtesting_data[pair.independent_stock]
+
+    return backtesting_spread.replace([np.inf, -np.inf], np.nan).dropna()

--- a/graph_data.py
+++ b/graph_data.py
@@ -1,10 +1,7 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from matplotlib.figure import Figure
 from pathlib import Path
-
-from config import ENTRY_THRESHOLD, EXIT_THRESHOLD
 
 def graph_backtesting(backtesting_results: pd.DataFrame) -> None:
     fig = plt.figure()
@@ -19,52 +16,12 @@ def graph_backtesting(backtesting_results: pd.DataFrame) -> None:
     exit_signals_filter = backtesting_results['Exits'] > 0
     capital_graph.scatter(backtesting_results['Entries'][entry_signals_filter].index, backtesting_results['Capital'][entry_signals_filter], marker='+', color='green', label='Entry Signal', alpha=0.5)
     capital_graph.scatter(backtesting_results['Exits'][exit_signals_filter].index, backtesting_results['Capital'][exit_signals_filter], marker='+', color='red', label='Exit Signal', alpha=0.5)
+    
     plt.xticks(rotation=30)
     plt.legend()
     fig.tight_layout()
     save_graph('backtesting_results')
     plt.show()
-
-def graph_pair_trade(stock1: str, stock2: str, pair_data: pd.DataFrame) -> None:
-    fig = plt.figure()
-    z_score = pair_data['Z-score']
-    start_date = z_score.first_valid_index()
-    graph_stocks(fig, stock1, stock2, pair_data, start_date)
-    graph_z_score(fig, z_score, start_date)
-    graph_capital(fig, pair_data, start_date)
-    fig.tight_layout()
-    save_graph(f'graphs_{stock1}_{stock2}')
-
-def graph_stocks(fig: Figure, stock1: str, stock2: str, pair_data: pd.DataFrame, start_date: pd.Timestamp) -> None:
-    pair_graph = fig.add_subplot(311)
-    pair_graph.plot(pair_data[stock1].index, pair_data[stock1].values, label=stock1, color='blue')
-    pair_graph.plot(pair_data[stock2].index, pair_data[stock2].values, label=stock2, color='orange')
-    pair_graph.set_xlim([start_date, pair_data[stock1].index[-1]])
-    plt.title('Stock prices')
-    plt.legend()
-    plt.xticks(rotation=30)
-
-def graph_z_score(fig: Figure, z_score: pd.Series, start_date: pd.Timestamp) -> None:
-    z_score_graph = fig.add_subplot(312)
-    z_score_graph.set_xlim([start_date, z_score.index[-1]])
-    z_score_graph_bound = z_score.abs().max() * 1.1
-    z_score_graph.set_ylim(-z_score_graph_bound, z_score_graph_bound)
-    z_score_graph.axhline(EXIT_THRESHOLD, color='grey', linestyle='--')
-    if EXIT_THRESHOLD > 0:
-        z_score_graph.axhline(-EXIT_THRESHOLD, color='grey', linestyle='--')
-    z_score_graph.axhline(ENTRY_THRESHOLD, color='red', linestyle='--')
-    z_score_graph.axhline(-ENTRY_THRESHOLD, color='red', linestyle='--')
-    z_score_graph.plot(z_score.index, z_score.values, label='Z-Score', color='black')
-    plt.title('Z-score')
-    plt.xticks(rotation=30)
-
-def graph_capital(fig: Figure, pair_data: pd.DataFrame, start_date: pd.Timestamp) -> None:
-    capital_graph = fig.add_subplot(313)
-    capital = pair_data['Capital']
-    capital_graph.plot(capital.index, capital.values, label='Capital', color='green')
-    capital_graph.set_xlim([start_date, capital.index[-1]])
-    plt.title('Capital')
-    plt.xticks(rotation=30)
 
 def save_graph(name: str) -> None:
     working_directory = Path(__file__).parent

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 from backtesting import get_roi, get_sharpe_ratio, perform_backtest
 from fetch_data import get_market_data, get_returns
 from graph_data import graph_backtesting
-from tickers import TICKERS
 from trading_signals import get_positions, get_signals
 from validate_pairs import get_cointegrated_pairs, get_correlated_pairs, get_selected_pairs, get_z_score
 
@@ -9,16 +8,20 @@ from validate_pairs import get_cointegrated_pairs, get_correlated_pairs, get_sel
 #tune several parameters and gauge sharpe ratio to select best combination
 
 def main() -> None:
-    market_data = get_market_data(TICKERS)
+    market_data = get_market_data()
     market_returns = get_returns(market_data)
     correlated_pairs = get_correlated_pairs(market_returns) # this ensures all hedge ratios are positive
     cointegrated_pairs_data = get_cointegrated_pairs(correlated_pairs, market_data)
     selected_pairs = get_selected_pairs(cointegrated_pairs_data)
 
     for pair in selected_pairs:
+        #each pair contains pair_data, which tracks the spread of the two stocks from 3-6 years ago.
+        #for backtesting, we know want to implement the strategy on the most recent 3 years of data.
+        #we use the same spread/hedge ratio. simply update pair.data['Spread'].
         pair.data['Z-score'] = get_z_score(pair.data['Spread'])
         pair.data['Position'] = get_positions(pair.data['Z-score'].dropna())
         pair.data['Signal'] = get_signals(pair.data['Position'])
+        print(f'Selected pair: {pair.dependent_stock} and {pair.independent_stock}')
 
     backtesting_results = perform_backtest(selected_pairs)
     roi = get_roi(backtesting_results['Capital'].iloc[-1])

--- a/main.py
+++ b/main.py
@@ -16,12 +16,9 @@ def main() -> None:
 
     for pair in selected_pairs:
         update_for_backtesting(pair)
-        #DEBUG HERE
-        #spread is correct, but z-score does not calculate as expected
         pair.data['Z-score'] = get_z_score(pair.data['Spread'])
         pair.data['Position'] = get_positions(pair.data['Z-score'].dropna())
         pair.data['Signal'] = get_signals(pair.data['Position'])
-        #print(f'Selected pair: {pair.dependent_stock} and {pair.independent_stock}')
 
     backtesting_results = perform_backtest(selected_pairs)
     roi = get_roi(backtesting_results['Capital'].iloc[-1])

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from backtesting import get_roi, get_sharpe_ratio, perform_backtest
-from fetch_data import get_backtesting_spread, get_historic_data, get_returns
+from fetch_data import get_historic_data, get_returns, update_for_backtesting
 from graph_data import graph_backtesting
 from trading_signals import get_positions, get_signals
 from validate_pairs import get_cointegrated_pairs, get_correlated_pairs, get_selected_pairs, get_z_score
@@ -15,9 +15,7 @@ def main() -> None:
     selected_pairs = get_selected_pairs(cointegrated_pairs_data)
 
     for pair in selected_pairs:
-        backtesting_spread = get_backtesting_spread(pair)
-        pair.data = pair.data.reindex(backtesting_spread.index)  # align indices
-        pair.data['Spread'] = backtesting_spread
+        update_for_backtesting(pair)
         #DEBUG HERE
         #spread is correct, but z-score does not calculate as expected
         pair.data['Z-score'] = get_z_score(pair.data['Spread'])

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from backtesting import get_roi, get_sharpe_ratio, perform_backtest
-from fetch_data import get_market_data, get_returns
+from fetch_data import get_backtesting_spread, get_historic_data, get_returns
 from graph_data import graph_backtesting
 from trading_signals import get_positions, get_signals
 from validate_pairs import get_cointegrated_pairs, get_correlated_pairs, get_selected_pairs, get_z_score
@@ -8,20 +8,22 @@ from validate_pairs import get_cointegrated_pairs, get_correlated_pairs, get_sel
 #tune several parameters and gauge sharpe ratio to select best combination
 
 def main() -> None:
-    market_data = get_market_data()
+    market_data = get_historic_data()
     market_returns = get_returns(market_data)
     correlated_pairs = get_correlated_pairs(market_returns) # this ensures all hedge ratios are positive
     cointegrated_pairs_data = get_cointegrated_pairs(correlated_pairs, market_data)
     selected_pairs = get_selected_pairs(cointegrated_pairs_data)
 
     for pair in selected_pairs:
-        #each pair contains pair_data, which tracks the spread of the two stocks from 3-6 years ago.
-        #for backtesting, we know want to implement the strategy on the most recent 3 years of data.
-        #we use the same spread/hedge ratio. simply update pair.data['Spread'].
+        backtesting_spread = get_backtesting_spread(pair)
+        pair.data = pair.data.reindex(backtesting_spread.index)  # align indices
+        pair.data['Spread'] = backtesting_spread
+        #DEBUG HERE
+        #spread is correct, but z-score does not calculate as expected
         pair.data['Z-score'] = get_z_score(pair.data['Spread'])
         pair.data['Position'] = get_positions(pair.data['Z-score'].dropna())
         pair.data['Signal'] = get_signals(pair.data['Position'])
-        print(f'Selected pair: {pair.dependent_stock} and {pair.independent_stock}')
+        #print(f'Selected pair: {pair.dependent_stock} and {pair.independent_stock}')
 
     backtesting_results = perform_backtest(selected_pairs)
     roi = get_roi(backtesting_results['Capital'].iloc[-1])


### PR DESCRIPTION
Previously the program tested for correlation/cointegration, and back-tested upon, the same dataset. This was incorrect, as in reality we should be establishing trading pairs/rules on historic data, then backtesting on unseen "future" data.

This branch fixes this by testing pairs in the time from of 3 to 6 years ago. It then backtests through the past 3 years.